### PR TITLE
Update to 1.11

### DIFF
--- a/BetterShardsBukkit/pom.xml
+++ b/BetterShardsBukkit/pom.xml
@@ -54,13 +54,13 @@
 		<dependency>
 			<groupId>org.spigotmc</groupId>
 			<artifactId>spigot</artifactId>
-			<version>1.10.2-R0.1-SNAPSHOT</version>
+			<version>1.11-R0.1-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>vg.civcraft.mc.mercury</groupId>
 			<artifactId>Mercury</artifactId>
-			<version>1.2.19</version>
+			<version>1.2.20</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
@@ -78,7 +78,7 @@
 		<dependency>
 			<groupId>net.minelink</groupId>
 			<artifactId>CombatTagPlus</artifactId>
-			<version>1.2.4-SNAPSHOT</version>
+			<version>1.3.0-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/BetterShardsBukkit/src/main/java/vg/civcraft/mc/bettershards/listeners/CombatTagListener.java
+++ b/BetterShardsBukkit/src/main/java/vg/civcraft/mc/bettershards/listeners/CombatTagListener.java
@@ -2,80 +2,76 @@ package vg.civcraft.mc.bettershards.listeners;
 
 import java.lang.reflect.Field;
 import java.util.logging.Level;
-
-import net.minecraft.server.v1_10_R1.EntityPlayer;
-import net.minecraft.server.v1_10_R1.FoodMetaData;
-import net.minecraft.server.v1_10_R1.NBTTagCompound;
-import net.minecraft.server.v1_10_R1.NBTTagList;
+import net.minecraft.server.v1_11_R1.EntityPlayer;
+import net.minecraft.server.v1_11_R1.FoodMetaData;
+import net.minecraft.server.v1_11_R1.NBTTagCompound;
+import net.minecraft.server.v1_11_R1.NBTTagList;
 import net.minelink.ctplus.compat.api.NpcIdentity;
-import net.minelink.ctplus.compat.v1_10_R1.NpcPlayer;
+import net.minelink.ctplus.compat.v1_11_R1.NpcPlayer;
 import net.minelink.ctplus.event.NpcDespawnEvent;
-
 import org.bukkit.Bukkit;
-import org.bukkit.craftbukkit.v1_10_R1.entity.CraftPlayer;
+import org.bukkit.craftbukkit.v1_11_R1.entity.CraftPlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
-
 import vg.civcraft.mc.bettershards.BetterShardsPlugin;
 import vg.civcraft.mc.bettershards.misc.CustomWorldNBTStorage;
 import vg.civcraft.mc.bettershards.misc.InventoryIdentifier;
 
 /**
- * This class is basically copied from 
- * https://github.com/Civcraft/CombatTagPlus
- * as the original programmers did a different way of saving the player data so it doesn't trigger MC.
- * We need to properly save the dead player.
+ * This class is basically copied from https://github.com/Civcraft/CombatTagPlus as the original programmers did a
+ * different way of saving the player data so it doesn't trigger MC. We need to properly save the dead player.
  */
-public class CombatTagListener implements Listener{
-	
+public class CombatTagListener implements Listener {
+
 	private CustomWorldNBTStorage storage = CustomWorldNBTStorage.getWorldNBTStorage();
-	
+
 	@EventHandler(priority = EventPriority.MONITOR)
 	public void combatTagPlusEntityDespawn(NpcDespawnEvent event) {
 		Player player = event.getNpc().getEntity();
 		EntityPlayer entity = ((CraftPlayer) player).getHandle();
 
-        if (!(entity instanceof NpcPlayer)) {
-            throw new IllegalArgumentException();
-        }
+		if (!(entity instanceof NpcPlayer)) {
+			throw new IllegalArgumentException();
+		}
 
-        NpcPlayer npcPlayer = (NpcPlayer) entity;
-        NpcIdentity identity = npcPlayer.getNpcIdentity();
-        Player p = Bukkit.getPlayer(identity.getId());
-        if (p != null && p.isOnline()) return;
-        
-        NBTTagCompound playerNbt = storage.getPlayerData(identity.getId());
-        if (playerNbt == null) {
-        	BetterShardsPlugin.getInstance().getLogger().log(Level.WARNING, 
-        			"Unable to load data for {0} during NPC despawn", identity.getId());
-        }
-        // foodTickTimer is now private in 1.8.3
-        Field foodTickTimerField;
-        int foodTickTimer;
+		NpcPlayer npcPlayer = (NpcPlayer) entity;
+		NpcIdentity identity = npcPlayer.getNpcIdentity();
+		Player p = Bukkit.getPlayer(identity.getId());
+		if (p != null && p.isOnline())
+			return;
 
-        try {
-            foodTickTimerField = FoodMetaData.class.getDeclaredField("foodTickTimer");
-            foodTickTimerField.setAccessible(true);
-            foodTickTimer = foodTickTimerField.getInt(entity.getFoodData());
-        } catch (NoSuchFieldException | IllegalAccessException e) {
-            throw new RuntimeException(e);
-        }
+		NBTTagCompound playerNbt = storage.getPlayerData(identity.getId());
+		if (playerNbt == null) {
+			BetterShardsPlugin.getInstance().getLogger()
+					.log(Level.WARNING, "Unable to load data for {0} during NPC despawn", identity.getId());
+		}
+		// foodTickTimer is now private in 1.8.3
+		Field foodTickTimerField;
+		int foodTickTimer;
 
-        playerNbt.setShort("Air", (short) entity.getAirTicks());
-        playerNbt.setFloat("HealF", entity.getHealth());
-        playerNbt.setShort("Health", (short) ((int) Math.ceil((double) entity.getHealth())));
-        playerNbt.setFloat("AbsorptionAmount", entity.getAbsorptionHearts());
-        playerNbt.setInt("XpTotal", entity.expTotal);
-        playerNbt.setInt("foodLevel", entity.getFoodData().foodLevel);
-        playerNbt.setInt("foodTickTimer", foodTickTimer);
-        playerNbt.setFloat("foodSaturationLevel", entity.getFoodData().saturationLevel);
-        playerNbt.setFloat("foodExhaustionLevel", entity.getFoodData().exhaustionLevel);
-        playerNbt.setShort("Fire", (short) entity.fireTicks);
-        playerNbt.set("Inventory", npcPlayer.inventory.a(new NBTTagList()));
-        
-        storage.save(identity.getId(), playerNbt, InventoryIdentifier.MAIN_INV, true);
+		try {
+			foodTickTimerField = FoodMetaData.class.getDeclaredField("foodTickTimer");
+			foodTickTimerField.setAccessible(true);
+			foodTickTimer = foodTickTimerField.getInt(entity.getFoodData());
+		} catch (NoSuchFieldException | IllegalAccessException e) {
+			throw new RuntimeException(e);
+		}
+
+		playerNbt.setShort("Air", (short) entity.getAirTicks());
+		playerNbt.setFloat("HealF", entity.getHealth());
+		playerNbt.setShort("Health", (short) ((int) Math.ceil(entity.getHealth())));
+		playerNbt.setFloat("AbsorptionAmount", entity.getAbsorptionHearts());
+		playerNbt.setInt("XpTotal", entity.expTotal);
+		playerNbt.setInt("foodLevel", entity.getFoodData().foodLevel);
+		playerNbt.setInt("foodTickTimer", foodTickTimer);
+		playerNbt.setFloat("foodSaturationLevel", entity.getFoodData().saturationLevel);
+		playerNbt.setFloat("foodExhaustionLevel", entity.getFoodData().exhaustionLevel);
+		playerNbt.setShort("Fire", (short) entity.fireTicks);
+		playerNbt.set("Inventory", npcPlayer.inventory.a(new NBTTagList()));
+
+		storage.save(identity.getId(), playerNbt, InventoryIdentifier.MAIN_INV, true);
 	}
 
 }

--- a/BetterShardsBukkit/src/main/java/vg/civcraft/mc/bettershards/misc/CustomWorldNBTStorage.java
+++ b/BetterShardsBukkit/src/main/java/vg/civcraft/mc/bettershards/misc/CustomWorldNBTStorage.java
@@ -11,39 +11,37 @@ import java.lang.reflect.Modifier;
 import java.nio.channels.FileLock;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.concurrent.ConcurrentHashMap;
-
+import net.minecraft.server.v1_11_R1.DataConverterManager;
+import net.minecraft.server.v1_11_R1.EntityHuman;
+import net.minecraft.server.v1_11_R1.EntityPlayer;
+import net.minecraft.server.v1_11_R1.IDataManager;
+import net.minecraft.server.v1_11_R1.MinecraftServer;
+import net.minecraft.server.v1_11_R1.NBTCompressedStreamTools;
+import net.minecraft.server.v1_11_R1.NBTTagCompound;
+import net.minecraft.server.v1_11_R1.ServerNBTManager;
+import net.minecraft.server.v1_11_R1.WorldNBTStorage;
+import net.minecraft.server.v1_11_R1.WorldServer;
 import org.apache.commons.io.IOUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.YamlConfiguration;
-import org.bukkit.craftbukkit.v1_10_R1.CraftWorld;
-import org.bukkit.craftbukkit.v1_10_R1.entity.CraftPlayer;
+import org.bukkit.craftbukkit.v1_11_R1.CraftWorld;
+import org.bukkit.craftbukkit.v1_11_R1.entity.CraftPlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
-
 import vg.civcraft.mc.bettershards.BetterShardsPlugin;
 import vg.civcraft.mc.bettershards.database.DatabaseManager;
-import net.minecraft.server.v1_10_R1.DataConverterManager;
-import net.minecraft.server.v1_10_R1.EntityHuman;
-import net.minecraft.server.v1_10_R1.EntityPlayer;
-import net.minecraft.server.v1_10_R1.IDataManager;
-import net.minecraft.server.v1_10_R1.MinecraftServer;
-import net.minecraft.server.v1_10_R1.NBTCompressedStreamTools;
-import net.minecraft.server.v1_10_R1.NBTTagCompound;
-import net.minecraft.server.v1_10_R1.ServerNBTManager;
-import net.minecraft.server.v1_10_R1.WorldNBTStorage;
-import net.minecraft.server.v1_10_R1.WorldServer;
 
 public class CustomWorldNBTStorage extends ServerNBTManager {
 
 	private DatabaseManager db;
-	
+
 	private static CustomWorldNBTStorage storage;
-	private Map<UUID, InventoryIdentifier> invs = new ConcurrentHashMap<UUID, InventoryIdentifier>(); 
+	private Map<UUID, InventoryIdentifier> invs = new ConcurrentHashMap<UUID, InventoryIdentifier>();
 	private Map<UUID, ConfigurationSection> sect = new ConcurrentHashMap<UUID, ConfigurationSection>();
 	private Logger logger = BetterShardsPlugin.getInstance().getLogger();
 
@@ -58,31 +56,31 @@ public class CustomWorldNBTStorage extends ServerNBTManager {
 		try {
 			UUID uuid = entityhuman.getUniqueID();
 			logger.log(Level.FINER, "EntityHuman]* Save player data for {0}", uuid);
-			
-			NBTTagCompound nbttagcompound = new NBTTagCompound();
 
+			NBTTagCompound nbttagcompound = new NBTTagCompound();
+			// e method dumps the data of an entity into a nbttagcompound, this includes inventory, location, health,
+			// respiration etc.
 			entityhuman.e(nbttagcompound);
-			//logInventory(nbttagcompound);
+			// logInventory(nbttagcompound);
 			ByteArrayOutputStream output = new ByteArrayOutputStream();
 			NBTCompressedStreamTools.a(nbttagcompound, output);
 
 			// Now to run our custom mysql code
 			if (!BetterShardsPlugin.getTransitManager().isPlayerInTransit(uuid)) {
 				db.savePlayerData(uuid, output, getInvIdentifier(uuid), sect.get(uuid));
-			}
-			else {
+			} else {
 				logger.log(Level.WARNING, "Did not save data for {0}, because he was in transit", entityhuman.getName());
 			}
 		} catch (Exception localException) {
 			logger.log(Level.SEVERE, "EntityHuman]* Failed to save player data for {0}", entityhuman.getName());
 		}
 	}
-	
+
 	public void save(NBTTagCompound nbttagcompound, UUID uuid) {
 		try {
 			logger.log(Level.FINER, "NBTTagCompound,UUID] Save player data for {0}", uuid);
 
-			//logInventory(nbttagcompound);
+			// logInventory(nbttagcompound);
 			ByteArrayOutputStream output = new ByteArrayOutputStream();
 			NBTCompressedStreamTools.a(nbttagcompound, output);
 
@@ -106,9 +104,9 @@ public class CustomWorldNBTStorage extends ServerNBTManager {
 		} catch (Exception localException) {
 			logger.log(Level.SEVERE, "EntityHuman]* Failed to load player data for {0}", entityhuman.getName());
 		}
-		
+
 		if (nbttagcompound != null) {
-			//logInventory(nbttagcompound);
+			// logInventory(nbttagcompound);
 			if ((entityhuman instanceof EntityPlayer)) {
 				CraftPlayer player = (CraftPlayer) entityhuman.getBukkitEntity();
 
@@ -117,6 +115,7 @@ public class CustomWorldNBTStorage extends ServerNBTManager {
 					player.setFirstPlayed(modified);
 				}
 			}
+			// f method loads data from an nbttagcompound into an entitiy, effectively overrriding any prexexisting data
 			entityhuman.f(nbttagcompound);
 		} else {
 			logger.log(Level.INFO, "EntityHuman]* No player data found for {0}", entityhuman.getName());
@@ -129,11 +128,11 @@ public class CustomWorldNBTStorage extends ServerNBTManager {
 		try {
 			UUID uuid = UUID.fromString(s);
 			logger.log(Level.FINER, "String]* get / load for " + uuid);
-			
+
 			ByteArrayInputStream input = db.loadPlayerData(uuid, getInvIdentifier(uuid));
 			NBTTagCompound nbttagcompound = NBTCompressedStreamTools.a(input);
-			//logInventory(nbttagcompound);
-			
+			// logInventory(nbttagcompound);
+
 			return nbttagcompound;
 		} catch (Exception localException) {
 			logger.log(Level.SEVERE, "String]* Failed to get / load player data for {0}", s);
@@ -144,11 +143,11 @@ public class CustomWorldNBTStorage extends ServerNBTManager {
 	public NBTTagCompound getPlayerData(UUID uuid) {
 		try {
 			logger.log(Level.FINER, "UUID] Get / Load player data for {0}", uuid);
-			
+
 			ByteArrayInputStream input = db.loadPlayerDataAsync(uuid, getInvIdentifier(uuid)).get();
 			NBTTagCompound nbttagcompound = NBTCompressedStreamTools.a(input);
-			//logInventory(nbttagcompound);
-			
+			// logInventory(nbttagcompound);
+
 			return nbttagcompound;
 		} catch (Exception localException) {
 			logger.log(Level.SEVERE, "UUID] Failed to get / load player data for {0}", uuid);
@@ -156,13 +155,13 @@ public class CustomWorldNBTStorage extends ServerNBTManager {
 		}
 		return null;
 	}
-	
+
 	public void load(Player p, InventoryIdentifier iden) {
 		UUID uuid = p.getUniqueId();
 		logger.log(Level.FINER, "Player,InvIdent] Load player data for {0}", uuid);
-		
+
 		CraftPlayer cPlayer = (CraftPlayer) p;
-		
+
 		NBTTagCompound nbttagcompound = null;
 		ByteArrayInputStream input = db.loadPlayerData(uuid, iden);
 		if (input != null) {
@@ -173,26 +172,26 @@ public class CustomWorldNBTStorage extends ServerNBTManager {
 				e.printStackTrace();
 			}
 		}
-		//logInventory(nbttagcompound);
+		// logInventory(nbttagcompound);
 		if (nbttagcompound == null) {
 			logger.log(Level.SEVERE, "Player,InvIdent] (Load) No player data for {0}", uuid);
 		}
 		cPlayer.getHandle().f(nbttagcompound); // why clear the inventory b/c load failed?
 	}
-	
+
 	public void save(Player p, InventoryIdentifier iden) {
 		save(p, iden, false);
 	}
-	
+
 	public void save(Player p, InventoryIdentifier iden, boolean async) {
 		UUID uuid = p.getUniqueId();
 		logger.log(Level.FINER, "Player,InvIdent,bool] Save player data for {0}", uuid);
-		
+
 		CraftPlayer cPlayer = (CraftPlayer) p;
-		
+
 		NBTTagCompound nbttagcompound = new NBTTagCompound();
 		cPlayer.getHandle().e(nbttagcompound);
-		//logInventory(nbttagcompound);
+		// logInventory(nbttagcompound);
 		ByteArrayOutputStream output = new ByteArrayOutputStream();
 		try {
 			NBTCompressedStreamTools.a(nbttagcompound, output);
@@ -200,26 +199,26 @@ public class CustomWorldNBTStorage extends ServerNBTManager {
 			logger.log(Level.SEVERE, "Player,InvIdent,bool] Failed to save player data for {0}", uuid);
 			logger.log(Level.SEVERE, "Player,InvIdent,bool] Failed to save player data, exception:", e);
 		}
-		
+
 		if (nbttagcompound == null || output == null) {
 			logger.log(Level.SEVERE, "Player,InvIdent,bool] (Save) No player data for {0}", uuid);
 		}
-		
-		if (async){
+
+		if (async) {
 			db.savePlayerDataAsync(uuid, output, iden, sect.get(uuid));
 		} else {
 			db.savePlayerData(uuid, output, iden, sect.get(uuid));
 		}
 	}
-	
+
 	public void save(UUID uuid, NBTTagCompound nbttagcompound, InventoryIdentifier iden) {
 		save(uuid, nbttagcompound, iden, false);
 	}
-	
+
 	public void save(UUID uuid, NBTTagCompound nbttagcompound, InventoryIdentifier iden, boolean async) {
 		logger.log(Level.FINER, "UUID,NBTTagCompound,InvIdent,bool] Save player data for {0}", uuid);
-		
-		//logInventory(nbttagcompound);
+
+		// logInventory(nbttagcompound);
 		ByteArrayOutputStream output = new ByteArrayOutputStream();
 		try {
 			NBTCompressedStreamTools.a(nbttagcompound, output);
@@ -231,7 +230,7 @@ public class CustomWorldNBTStorage extends ServerNBTManager {
 		if (nbttagcompound == null || output == null) {
 			logger.log(Level.SEVERE, "UUID,NBTTagCompound,InvIdent,bool] (Save) No player data for {0}", uuid);
 		}
-		
+
 		if (async) {
 			db.savePlayerDataAsync(uuid, output, iden, sect.get(uuid));
 		} else {
@@ -242,24 +241,27 @@ public class CustomWorldNBTStorage extends ServerNBTManager {
 	public static CustomWorldNBTStorage getWorldNBTStorage() {
 		return storage;
 	}
-	
+
 	public InventoryIdentifier getInvIdentifier(UUID uuid) {
 		if (!invs.containsKey(uuid))
 			invs.put(uuid, InventoryIdentifier.MAIN_INV);
 		return invs.get(uuid);
 	}
-	
+
 	public void loadConfigurationSectionForPlayer(UUID uuid, ConfigurationSection section) {
 		sect.put(uuid, section);
 	}
-	
-	/** 
-	 * Gets a ConfigurationSection that allows other plugins to store data that will be saved in the 
-	 * PlayerNBT Storage. Keep in mind the ConfigurationSection returned will be autosaved on save.
-	 * If there is a previous ConfigurationSection this plugin will load it and return it.
-	 * @param uuid The uuid of the player.
-	 * @param plugin The name of the plugin for tracking purposes.
-	 * @return Returns a ConfigurationSection that can be used by a plugin.  
+
+	/**
+	 * Gets a ConfigurationSection that allows other plugins to store data that will be saved in the PlayerNBT Storage.
+	 * Keep in mind the ConfigurationSection returned will be autosaved on save. If there is a previous
+	 * ConfigurationSection this plugin will load it and return it.
+	 * 
+	 * @param uuid
+	 *          The uuid of the player.
+	 * @param plugin
+	 *          The name of the plugin for tracking purposes.
+	 * @return Returns a ConfigurationSection that can be used by a plugin.
 	 */
 	public ConfigurationSection getConfigurationSection(UUID uuid, JavaPlugin plugin) {
 		ConfigurationSection configSect = sect.get(uuid);
@@ -273,38 +275,41 @@ public class CustomWorldNBTStorage extends ServerNBTManager {
 		}
 		return pluginSect;
 	}
-	
+
 	/**
-	 * Sets the InventoryIdentifier of a player while logging in.
-	 * It is very important that you call this method during the 
-	 * AsyncPreLoginEvent with an event priority below Monitor to ensure
-	 * that the inventory you want is loaded.
-	 * Otherwise just call load(Player, InventoryIdentifier) to load your inv.
-	 * You need to remember to reset InventoryIdentifier back to normal load if
-	 * you wish for to be set back to that.  It will not do that on its own.
-	 * @param uuid The uuid of the player.
-	 * @param iden The Inventory you wan't to load for a player.
+	 * Sets the InventoryIdentifier of a player while logging in. It is very important that you call this method during
+	 * the AsyncPreLoginEvent with an event priority below Monitor to ensure that the inventory you want is loaded.
+	 * Otherwise just call load(Player, InventoryIdentifier) to load your inv. You need to remember to reset
+	 * InventoryIdentifier back to normal load if you wish for to be set back to that. It will not do that on its own.
+	 * 
+	 * @param uuid
+	 *          The uuid of the player.
+	 * @param iden
+	 *          The Inventory you wan't to load for a player.
 	 */
 	public void setInventoryIdentifier(UUID uuid, InventoryIdentifier iden) {
 		invs.put(uuid, iden);
 	}
-	
+
 	/**
 	 * Only called when enabling the plugin to replace minecraft's internal player data handling with BetterShards'
 	 */
 	public static void setWorldNBTStorage() {
-		for (World w: Bukkit.getWorlds()) {
+		for (World w : Bukkit.getWorlds()) {
 			WorldServer nmsWorld = ((CraftWorld) w).getHandle();
 			Field fieldName;
 			try {
-				fieldName = net.minecraft.server.v1_10_R1.World.class.getDeclaredField("dataManager");
+				fieldName = net.minecraft.server.v1_11_R1.World.class.getDeclaredField("dataManager");
 				fieldName.setAccessible(true);
-				
+
 				IDataManager manager = nmsWorld.getDataManager();
-				
+
+				// the following line and try block were made for one of civcrafts custom spigot patches
+				// we're gonna leave it here commented out in case it's ever needed again.
+				// only rourke750 knows what this actually does
 				// Spigot has a file lock we want to try remove before invoking our own stuff.
 				WorldNBTStorage nbtManager = ((WorldNBTStorage) manager);
-				
+
 				try {
 					Field f = nbtManager.getClass().getSuperclass().getDeclaredField("sessionLock");
 					f.setAccessible(true);
@@ -312,10 +317,10 @@ public class CustomWorldNBTStorage extends ServerNBTManager {
 					sessionLock.close();
 				} catch (Exception e) {
 				}
-				
+
 				CustomWorldNBTStorage newStorage = new CustomWorldNBTStorage(manager.getDirectory(), "", true);
 				setFinalStatic(fieldName, newStorage, nmsWorld);
-				
+
 				MinecraftServer.getServer().getPlayerList().playerFileData = newStorage;
 			} catch (NoSuchFieldException e) {
 				// TODO Auto-generated catch block
@@ -326,7 +331,7 @@ public class CustomWorldNBTStorage extends ServerNBTManager {
 			}
 		}
 	}
-	
+
 	private static void setFinalStatic(Field field, Object newValue, Object obj) {
 		try {
 			field.setAccessible(true);
@@ -335,9 +340,8 @@ public class CustomWorldNBTStorage extends ServerNBTManager {
 			Field modifiersField;
 			modifiersField = Field.class.getDeclaredField("modifiers");
 			modifiersField.setAccessible(true);
-			modifiersField
-					.setInt(field, field.getModifiers() & ~Modifier.PROTECTED);
-			
+			modifiersField.setInt(field, field.getModifiers() & ~Modifier.PROTECTED);
+
 			field.set(obj, newValue);
 		} catch (NoSuchFieldException e) {
 			e.printStackTrace();
@@ -349,29 +353,30 @@ public class CustomWorldNBTStorage extends ServerNBTManager {
 			e.printStackTrace();
 		}
 	}
-	
+
 	public static void uploadExistingPlayers() {
 		if (!BetterShardsPlugin.getInstance().getConfig().getBoolean("import_playerdata")) {
 			return;
 		}
-		for (World w: Bukkit.getWorlds()) {
+		for (World w : Bukkit.getWorlds()) {
 			WorldServer nmsWorld = ((CraftWorld) w).getHandle();
 			IDataManager data = nmsWorld.getDataManager();
 			String[] names = data.getPlayerFileData().getSeenPlayers();
-			for (String name: names) {
+			for (String name : names) {
 				Bukkit.getLogger().log(Level.INFO, "Updating player " + name + " to mysql.");
 				try {
 					File file = new File(data.getDirectory() + File.separator + "playerdata", name + ".dat");
 					if (!file.exists())
 						continue;
 					InputStream stream = new FileInputStream(file);
-					
+
 					ByteArrayOutputStream output = new ByteArrayOutputStream();
 					output.write(IOUtils.toByteArray(stream));
 					// Now to run our custom mysql code
 					UUID uuid = UUID.fromString(name);
 					CustomWorldNBTStorage storage = getWorldNBTStorage();
-					BetterShardsPlugin.getDatabaseManager().savePlayerDataAsync(uuid, output, storage.getInvIdentifier(uuid), new YamlConfiguration());
+					BetterShardsPlugin.getDatabaseManager().savePlayerDataAsync(uuid, output, storage.getInvIdentifier(uuid),
+							new YamlConfiguration());
 					file.delete();
 					stream.close();
 				} catch (Exception localException) {

--- a/BetterShardsBungee/pom.xml
+++ b/BetterShardsBungee/pom.xml
@@ -73,21 +73,21 @@
     <dependency>
       <groupId>net.md-5</groupId>
       <artifactId>bungeecord-protocol</artifactId>
-      <version>1.10-SNAPSHOT</version>
+      <version>1.11-SNAPSHOT</version>
       <scope>provided</scope>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>net.md-5</groupId>
       <artifactId>bungeecord-api</artifactId>
-      <version>1.10-SNAPSHOT</version>
+      <version>1.11-SNAPSHOT</version>
       <scope>provided</scope>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>vg.civcraft.mc.mercury</groupId>
       <artifactId>Mercury</artifactId>
-      <version>1.2.19</version>
+      <version>1.2.20</version>
       <scope>provided</scope>
     </dependency>
 <!--     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	<url>https://github.com/Civcraft/BetterShards/</url>
 
 	<properties>
-		<releaseVersion>1.5.1</releaseVersion>
+		<releaseVersion>1.5.2</releaseVersion>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>


### PR DESCRIPTION
Diff is a bit messed up due to some of the formatting being applied unintentionally, but should be okay. I went through all the fields, confirmed they were the same and didnt change any actualy code except for rourkes custom civcraft field, which I commented out with an explaination there. Otherwise it's just standard 1.10_R1 --> 1.11_R1 and some maven stuff.

Note that this relies on the updated Mercury 1.2.20 for which I made a PR earlier and CTPs 1.11 version, which is 1.3.0, which is not merged into Devoted's fork yet, so those should be done beforehand.


This was tested on a server and seemed to work (startup and loading/saving data)